### PR TITLE
Review Evaluate.c

### DIFF
--- a/src/Evaluate.c
+++ b/src/Evaluate.c
@@ -177,6 +177,7 @@ void evaluatePostfixesAndInfix(Token *token, String *expression, Stack *dataStac
       Throw( ERR_NOT_EXPECTING_PREFIX_OPERATOR);
     else if( opr->info->affix == POSTFIX ) {
 		 oprForExecute = stackPeep( operatorStack);     
+		 		// If I ever see this OPEN_BRACKET here again I am going to fail you!!! Please Redo!!!
 				if(( oprForExecute != NULL) && (oprForExecute->info->id!=OPEN_BRACKET) ){        //this process is used to execute the execution inside the bracket
 					oprForExecute = stackPop( operatorStack);																			 //if the operator is not openingBracket, then will do execution 
 					oprForExecute->info->execute( dataStack , operatorStack ); 

--- a/test/test_StringObject.c
+++ b/test/test_StringObject.c
@@ -260,6 +260,7 @@ void test_stringRemoveWordContaining_tab_AB_plus_CD_tab_should_remove_nothing(vo
 	stringDel(str);
 }
 
+// This test causes my machine to throw system protection fault
 /*
  * Given " Beef " and containSet "f"
  * when call stringRemoveWordContaining x2 should remove nothing and str->length should 0
@@ -285,6 +286,7 @@ void test_stringRemoveWordContaining_Beef_and_call_stringRemoveWordContaining_x2
 	stringDel(str);
 }
 
+// This test causes my machine to throw system protection fault
 /*
  * given " 123 + 65 * 91 " and containSet "0123456789"
  * After call stringRemoveWordContaining x4 should remove nothing and str->length is 0
@@ -831,6 +833,7 @@ void test_stringRemoveOperator_minus_plus_operator_and_opSet_should_get_minus_op
 	stringDel(str);
 }
 
+// This test causes my machine to throw system protection fault
 /*
  * Given string "&" and operator set
  * should remove only one operator "&", start index = 0 and length is 2
@@ -918,6 +921,7 @@ void test_stringRemoveOperator_logical_OR_operator_and_opSet_should_get_logical_
 	stringDel(str);
 }
 
+// This test causes my machine to throw system protection fault
 /*
  * Given string "4" and operator set
  * should remove only one operator "||", start index = 0 and length is 2


### PR DESCRIPTION
I have told you many times that no OPEN_BRACKET in evaluatePostfixesAndInfix().
I will fail you if it ever in there! Please redo evaluatePostfixesAndInfix(). It is
unnecessarily long winded. Please start afresh from unit tests.
